### PR TITLE
Extended specification for smooth token type and functions

### DIFF
--- a/doc-design/source/_static/custom.css
+++ b/doc-design/source/_static/custom.css
@@ -145,6 +145,10 @@ h1{
   font-size: 1.2em;
 }
 
+.h5, h5{
+  font-style: italic;
+}
+
 blockquote{
   font-size: 1em;
   border-left: 0pt;

--- a/doc-design/source/softwareArchitecture.rst
+++ b/doc-design/source/softwareArchitecture.rst
@@ -394,6 +394,148 @@ so it can update them.
 We therefore propose to add time event handlers along with their dependencies
 to the ``EventIndicatorHandlers`` introduced in :ref:`subsec_se`.
 
+
+Events with boolean conditionals
+................................
+
+How does JModelica deal with zero crossing with conditionals which have boolean expressions such as
+
+.. code-block:: modelica
+
+  model ZCBoolean
+    "This model tests state event detection with boolean zero crossing"
+    extends Modelica.Icons.Example;
+    Real x(start=1, fixed=true);
+    Real u "Internal input signal";
+    Boolean yBoo "Boolean variable";
+    discrete Modelica.Blocks.Interfaces.RealOutput y(start=1.0, fixed=true);
+  initial equation 
+    pre(yBoo) = true;
+  equation 
+    u = Modelica.Math.sin(time);
+    der(x) = y;
+    when (pre(yBoo) and u >= 0.5) then
+      y = 1.0;
+      yBoo = false;
+    elsewhen (not pre(yBoo) and u <= -0.5) then
+      y = 1.0;
+      yBoo = true;
+    end when;
+  end ZCBoolean;
+
+Does JModelica generate two zero crossing functions which represent the 
+conditionals?
+
+SmoothToken for QSS
+"""""""""""""""""""
+
+This section discusses a proposal for a new data type which should be used for input and output variables of FMU-QSS.
+FMU-QSS is an FMU for Model Exchange (FMU-ME) which uses QSS to integrate an imported FMU-ME.
+We propose that FMU-QSS communicates with other FMUs using a SmoothToken data type.
+
+A smooth token is a timestamped event that has a real value (approximated as a ``double``)
+that represents the current sample of a real-valued smooth signal. But in addition to the sample value,
+the smooth token contains zero or more time-derivatives of the signal at the stored timestamp.
+For example, in the figure below, FMU-ME has a real input :math:`u` and a real output :math:`y`.
+A smooth token of the input variable will be a variable :math:`u^* \triangleq [u, n, du/dt, ...,  d^n u/dt^n, t_u]`,
+where :math:`n \in \{0, 1, 2, \ldots \}` is a parameter that defines the number of time derivatives that are present in the smooth token and
+:math:`t_u` is the timestamp of the smooth token.
+If :math:`u^*` has a discontinuity at :math:`t_u`,
+then the derivatives are the derivatives from above, e.g., :math:`du/dt \triangleq \lim_{s \downarrow 0} (u(t_u+s)-u(t_u))/s`.
+
+At simulation time :math:`t`, FMU-QSS will receive :math:`u^*` and convert it to a real signal
+using the Taylor expansion
+
+.. math::
+
+   y_s(t) = \frac{u^{(n)}(t_u)}{n!} \, (t-t_u)^n,
+
+where :math:`u^{(n)}` denotes the :math:`n`-th derivative. As shown in :numref:`fig-fmu-qss`, the FMU-ME will receive
+the value :math:`y_s(t)`.
+
+
+.. _fig-fmu-qss:
+
+.. figure:: img/fmu-qss.*
+   :scale: 55 %
+
+   Conversion of input signal between FMU-QSS and FMU-ME.
+
+To avoid frequent changes in the input signal, each input signal will have a quantum defined.
+The quantum :math:`dq` will be computed at runtime as
+:math:`\delta q = \epsilon_{rel} \, |u^-|`,
+where :math:`\epsilon_{rel}` is the relative tolerance and :math:`u^-`
+is the last value seen at the input of FMU-ME. The initial value is :math:`\delta q_0 = \epsilon_{rel} \, u_0`.
+The input signal will be updated only if it has changed by more than a quantum,
+
+.. math::
+
+   |y_s(t) - u^-| \ge \delta q = \max(\epsilon_{rel} \, |u^-|, \epsilon_{abs}),
+
+where :math:`\epsilon_{abs}` is the absolute tolerance, set to :math:`\epsilon_{abs} \triangleq \epsilon_{rel} \, |u_{nom}|`,
+where :math:`u_{nom}` is the nominal value of the variable :math:`u`.
+
+
+**Adding a new data type and two new FMI functions for SmoothToken**:
+
+To support the smooth token data type, we propose to add following data-type to the FMI specification
+
+.. code::
+
+    typedef struct {
+      size_t n;
+      fmi2Real value;
+      fmi2ValueReference vr;
+      fmi2Real derivatives[];
+      fmi2Real t;
+     } SmoothToken;
+
+where ``n`` is is the number of time derivatives of a smooth signal, ``value`` is the current sample of 
+the smooth signal, ``vr`` is the value reference of the FMU-ME scalar variable for which a smooth token is constructed, ``derivatives`` are the time derivatives of the FMU-ME scalar variable (e.g. ``derivatives[0]`` is the first time derivative, ``derivatives[1]`` is the second time derivative), and ``t`` is the timestamp of the smooth token.
+
+To set the value of a smooth token, we propose to add a new function ``fmi2SetStruct`` defined as
+
+.. code-block:: c
+
+  fmi2Status fmi2SetStruct(fmi2Component c,
+                         SmoothToken val);
+
+where ``val`` is the value of the SmoothToken to be set.
+
+To get the value of a smooth token, we propose to add a new function ``fmi2GetStruct`` defined as
+
+.. code-block:: c
+
+  fmi2Status fmi2GetStruct(fmi2Component c,
+                         fmi2ValueReference vr;
+                         SmoothToken val);
+
+where ``vr`` is the value reference of the FMU-ME variable to be retrieved, and ``val`` is its corresponding SmoothToken.
+
+
+.. note::
+
+    We need to implement how a smooth token will be modified if its value is for instance multiplied by a scalar or another smooth token. 
+    This is particularly important for smooth token outputs which will be used as inputs of other FMUs.
+
+
+**Add fmi2GetRealOutputDerivatives for FMU for Model Exchange**:
+
+In the above section, we proposed to use smooth token for input and output variables of FMU-QSS.
+Since a smooth token can include derivatives information, we propose to extend the specification to provide 
+a function which can be used to get derivatives of FMU-ME output variables which will be used as inputs 
+of other FMUs. These derivatives can be used to parametrize the smooth token of the FMU inputs variables.
+We propose to extend the FMI for ME API to include the function ``fmi2GetRealOutputDerivatives`` which exists
+for the FMI for co-simulation API.
+
+.. note::
+
+   - If a tool can not provide the derivative of an ouput variable with respect to time, ``fmi2GetRealOutputDerivatives`` should return an error.
+     In which case, a tool could approximate the output derivative using current and past output values e.g., :math:`dy/dt \triangleq \lim_{s \uparrow 0} (y(t_u)-y(t_u-s))/s`.
+
+   - For FMU-ME, if the ouput ``y`` has a direct feedthrough on the input ``u`` e.g., :math:`y=f(u)`, then :math:`\frac{dy}{dt}` which equals :math:`\frac{df(u)}{dt} \cdot \frac{du}{dt}` cannot be computed since it requires to know the value of :math:`\frac{du}{dt}`.
+
+
 :numref:`fig_sof_arc_qss_jmod2` shows the software architecture
 with the extended FMI API.
 For simplicity the figure only
@@ -586,146 +728,7 @@ If the number of event indicators does not match, the FMU needs to be rejected w
   Hence the master algorithm needs to detect if the tool which exported the FMU is Dymola, and if it is, the
   number of event indicator functions must be equal to half the value of the ``numberOfEventIndicators`` attribute.
 
-SmoothToken for QSS
-~~~~~~~~~~~~~~~~~~~
 
-
-This section discusses a proposal for a new data type which should be used for input and output variables of FMU-QSS.
-FMU-QSS is an FMU for Model Exchange (FMU-ME) which uses QSS to integrate an imported FMU-ME.
-We propose that FMU-QSS communicates with other FMUs using a SmoothToken data type.
-
-A smooth token is a timestamped event that has a real value (approximated as a ``double``)
-that represents the current sample of a real-valued smooth signal. But in addition to the sample value,
-the smooth token contains zero or more time-derivatives of the signal at the stored timestamp.
-For example, in the figure below, FMU-ME has a real input :math:`u` and a real output :math:`y`.
-A smooth token of the input variable will be a variable :math:`u^* \triangleq [u, n, du/dt, ...,  d^n u/dt^n, t_u]`,
-where :math:`n \in \{0, 1, 2, \ldots \}` is a parameter that defines the number of time derivatives that are present in the smooth token and
-:math:`t_u` is the timestamp of the smooth token.
-If :math:`u^*` has a discontinuity at :math:`t_u`,
-then the derivatives are the derivatives from above, e.g., :math:`du/dt \triangleq \lim_{s \downarrow 0} (u(t_u+s)-u(t_u))/s`.
-
-At simulation time :math:`t`, FMU-QSS will receive :math:`u^*` and convert it to a real signal
-using the Taylor expansion
-
-.. math::
-
-   y_s(t) = \frac{u^{(n)}(t_u)}{n!} \, (t-t_u)^n,
-
-where :math:`u^{(n)}` denotes the :math:`n`-th derivative. As shown in :numref:`fig-fmu-qss`, the FMU-ME will receive
-the value :math:`y_s(t)`.
-
-
-.. _fig-fmu-qss:
-
-.. figure:: img/fmu-qss.*
-   :scale: 55 %
-
-   Conversion of input signal between FMU-QSS and FMU-ME.
-
-To avoid frequent changes in the input signal, each input signal will have a quantum defined.
-The quantum :math:`dq` will be computed at runtime as
-:math:`\delta q = \epsilon_{rel} \, |u^-|`,
-where :math:`\epsilon_{rel}` is the relative tolerance and :math:`u^-`
-is the last value seen at the input of FMU-ME. The initial value is :math:`\delta q_0 = \epsilon_{rel} \, u_0`.
-The input signal will be updated only if it has changed by more than a quantum,
-
-.. math::
-
-   |y_s(t) - u^-| \ge \delta q = \max(\epsilon_{rel} \, |u^-|, \epsilon_{abs}),
-
-where :math:`\epsilon_{abs}` is the absolute tolerance, set to :math:`\epsilon_{abs} \triangleq \epsilon_{rel} \, |u_{nom}|`,
-where :math:`u_{nom}` is the nominal value of the variable :math:`u`.
-
-
-**Adding a new data type and two new FMI functions for SmoothToken**:
-
-To support the smooth token data type, we propose to add following data-type to the FMI specification
-
-.. code::
-
-    typedef struct {
-      size_t n;
-      fmi2Real value;
-      fmi2ValueReference vr;
-      fmi2Real derivatives[];
-      fmi2Real t;
-     } SmoothToken;
-
-where ``n`` is is the number of time derivatives of a smooth signal, ``value`` is the current sample of 
-the smooth signal, ``vr`` is the value reference of the FMU-ME scalar variable for which a smooth token is constructed, ``derivatives`` are the time derivatives of the FMU-ME scalar variable (e.g. ``derivatives[0]`` is the first time derivative, ``derivatives[1]`` is the second time derivative), and ``t`` is the timestamp of the smooth token.
-
-To set the value of a smooth token, we propose to add a new function ``fmi2SetStruct`` defined as
-
-.. code-block:: c
-
-  fmi2Status fmi2SetStruct(fmi2Component c,
-                         SmoothToken val);
-
-where ``val`` is the value of the SmoothToken to be set.
-
-To get the value of a smooth token, we propose to add a new function ``fmi2GetStruct`` defined as
-
-.. code-block:: c
-
-  fmi2Status fmi2GetStruct(fmi2Component c,
-                         fmi2ValueReference vr;
-                         SmoothToken val);
-
-where ``vr`` is the value reference of the FMU-ME variable to be retrieved, and ``val`` is its corresponding SmoothToken.
-
-
-.. note::
-
-    We need to implement how a smooth token will be modified if its value is for instance multiplied by a scalar or another smooth token. 
-    This is particularly important for smooth token outputs which will be used as inputs of other FMUs.
-
-
-**Add fmi2GetRealOutputDerivatives for FMU for Model Exchange**:
-
-In the above section, we proposed to use smooth token for input and output variables of FMU-QSS.
-Since a smooth token can include derivatives information, we propose to extend the specification to provide 
-a function which can be used to get derivatives of FMU-ME output variables which will be used as inputs 
-of other FMUs. These derivatives can be used to parametrize the smooth token of the FMU inputs variables.
-We propose to extend the FMI for ME API to include the function ``fmi2GetRealOutputDerivatives`` which exists
-for the FMI for co-simulation API.
-
-.. note::
-
-   - If a tool can not provide the derivative of an ouput variable with respect to time, ``fmi2GetRealOutputDerivatives`` should return an error.
-     In which case, a tool could approximate the output derivative using current and past output values e.g., :math:`dy/dt \triangleq \lim_{s \uparrow 0} (y(t_u)-y(t_u-s))/s`.
-
-   - For FMU-ME, if the ouput ``y`` has a direct feedthrough on the input ``u`` e.g., :math:`y=f(u)`, then :math:`\frac{dy}{dt}` which equals :math:`\frac{df(u)}{dt} \cdot \frac{du}{dt}` cannot be computed since it requires to know the value of :math:`\frac{du}{dt}`.
-
-Open Topic -- Zerocrossing with boolean conditionals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-How does JModelica deal with zero crossing with conditionals which have boolean expressions such as
-
-.. code-block:: modelica
-
-  model ZCBoolean
-    "This model tests state event detection with boolean zero crossing"
-    extends Modelica.Icons.Example;
-    Real x(start=1, fixed=true);
-    Real u "Internal input signal";
-    Boolean yBoo "Boolean variable";
-    discrete Modelica.Blocks.Interfaces.RealOutput y(start=1.0, fixed=true);
-  initial equation 
-    pre(yBoo) = true;
-  equation 
-    u = Modelica.Math.sin(time);
-    der(x) = y;
-    when (pre(yBoo) and u >= 0.5) then
-      y = 1.0;
-      yBoo = false;
-    elsewhen (not pre(yBoo) and u <= -0.5) then
-      y = 1.0;
-      yBoo = true;
-    end when;
-  end ZCBoolean;
-
-Does JModelica generate two zero crossing functions which represent the 
-conditionals?
 
 
 

--- a/doc-design/source/softwareArchitecture.rst
+++ b/doc-design/source/softwareArchitecture.rst
@@ -478,7 +478,7 @@ where :math:`u_{nom}` is the nominal value of the variable :math:`u`.
 
 **Adding a new data type and two new FMI functions for SmoothToken**:
 
-To support the smooth token data type, we propose to add following data-type to the FMI specification
+To support the smooth token data type, we propose to add following data type to the FMI specification
 
 .. code::
 
@@ -500,7 +500,7 @@ To set the value of a smooth token, we propose to add a new function ``fmi2SetSt
   fmi2Status fmi2SetStruct(fmi2Component c,
                          SmoothToken val);
 
-where ``val`` is the value of the SmoothToken to be set.
+where ``val`` is the value of the smooth token to be set.
 
 To get the value of a smooth token, we propose to add a new function ``fmi2GetStruct`` defined as
 
@@ -510,7 +510,7 @@ To get the value of a smooth token, we propose to add a new function ``fmi2GetSt
                          fmi2ValueReference vr;
                          SmoothToken val);
 
-where ``vr`` is the value reference of the FMU-ME variable to be retrieved, and ``val`` is its corresponding SmoothToken.
+where ``vr`` is the value reference of the FMU-ME variable to be retrieved, and ``val`` is its corresponding smooth token.
 
 
 .. note::

--- a/doc-design/source/softwareArchitecture.rst
+++ b/doc-design/source/softwareArchitecture.rst
@@ -524,7 +524,7 @@ where ``vr`` is the value reference of the FMU-ME variable to be retrieved, and 
 In the above section, we proposed to use smooth token for input and output variables of FMU-QSS.
 Since a smooth token can include derivatives information, we propose to extend the specification to provide 
 a function which can be used to get derivatives of FMU-ME output variables which will be used as inputs 
-of other FMUs. These derivatives can be used to parametrize the smooth token of the FMU inputs variables.
+of other FMUs. These derivatives can be used to parametrize the smooth token of the FMU input variables.
 We propose to extend the FMI for ME API to include the function ``fmi2GetRealOutputDerivatives`` which exists
 for the FMI for co-simulation API.
 


### PR DESCRIPTION
@mwetter Could you please review some changes and proposed extensions to the spec. I now defined how a smooth token could be and added new FMI functions needed to set and get them. I also added a section on derivatives of output variables. I would like to share the document with Modelon tomorrow evening.