### PR TITLE
Updated documentation

### DIFF
--- a/doc-design/source/softwareArchitecture.rst
+++ b/doc-design/source/softwareArchitecture.rst
@@ -343,7 +343,7 @@ This model has one event indicator function :math:`z=x-1`.
 For QSS, the FMU which exports this model must declare
 in the model description file that the event indicator handler ``y``
 depends on the event indicator function ``z``. This is needed so the QSS
-solver is notfied that ``y`` was updated because of a state event
+solver is notified when ``y`` is updated because of a state event.
 
 Therefore we require that all variables which depend
 on event indicator variables are listed in the

--- a/doc-design/source/softwareArchitecture.rst
+++ b/doc-design/source/softwareArchitecture.rst
@@ -452,8 +452,6 @@ with zero crossing functions which have boolean expressions such as
     end when;
   end ZCBoolean;
 
-Does JModelica generate two zero crossing functions which represent the
-conditionals?
 
 SmoothToken for QSS
 """""""""""""""""""


### PR DESCRIPTION
@mwetter I think we don't need to have fmi2setReal setting output variables. We could ask the QSS solver for the quantized state variables when invoking fmi2GetReal. So I removed this requirement from the document.
Please review and merge so I can send that along with the meeting minutes and the doodle poll.